### PR TITLE
Remove unnecessary Documenter dependency.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 1.0
-Documenter
 LabelNumerals 0.1.0
 RomanNumerals 0.3.1
 AdobeGlyphList 0.1.0


### PR DESCRIPTION
Hi, as you may know we are working on a breaking release of Documenter. Therefore, we are putting upperbounds on the packages that have Documenter as a direct dependency (https://github.com/JuliaLang/METADATA.jl/pull/19162) but I noticed that this package have a dependency on Documenter for no reason. This PR removes that.