### PR TITLE
bump compats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PDFIO"
 uuid = "4d0d745f-9d9a-592e-8d18-1ad8a0f42b92"
 authors = ["Sambit Kumar Dash<sambitdash@gmail.com> "]
-version = "0.1.14"
+version = "0.1.15"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -20,14 +20,26 @@ RomanNumerals = "37834d88-8936-577c-80c9-1066ecf66832"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
-BinDeps = "1.0"
-OpenSSL_jll = "1.1"
+AbstractTrees = "0.4"
+AdobeGlyphList = "0.1"
+BinDeps = "1"
+Dates = "1"
+DelimitedFiles = "1"
+LabelNumerals = "0.1"
+Libdl = "1"
+LinearAlgebra = "1"
+OpenSSL_jll = "1"
+Pkg = "1"
+Printf = "1"
+Rectangle = "0.1"
+RomanNumerals = "0.3"
+Zlib_jll = "1"
 julia = "1.6"
 
 [extras]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [targets]
 test = ["Test", "ZipFile", "Downloads"]


### PR DESCRIPTION
Added compats for all packages + bump to newer versions.

Unfortunately some tests fail with the certificates
```
  Got exception outside of a @test                                           
  KeyError: key :certs not found                                             
  Stacktrace:                                                                
    [1] getindex(h::Dict{Symbol, Any}, key::Symbol)                          
      @ Base ./dict.jl:477                                                   
    [2] pdDocValidateSignatures(doc::PDFIO.PD.PDDocImpl; export_certs::Bool) 
```
Any insights @sambitdash? - I now more or less nothing about PDFs :shrug:

Adresses #116 

---
Edit: I tried bumping OpenSSL_jll to "3" - but it just results in more tests failling in that area